### PR TITLE
ci: drop go 1.25 from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.25', '1.26']
+        go: ['1.26']
     name: 'test (go ${{ matrix.go }})'
     runs-on: ubuntu-latest
     needs: check-go


### PR DESCRIPTION
## Summary

CI has been failing on every push to `main` since #12 merged — the `test (go 1.25)` matrix leg can never pass:

```
go: go.mod requires go >= 1.26 (running go 1.25.12; GOTOOLCHAIN=local)
```

`go.mod` deliberately requires `go 1.26` (matching `penny`'s go directive). The CI workflow's test matrix (`['1.25', '1.26']`) was copied from gadget core's CI template, where it's correct because gadget core's own `go.mod` only requires `go 1.25`. Copied verbatim into this repo, the 1.25 leg is impossible by construction.

Fix: drop `'1.25'` from this repo's matrix, leaving just `['1.26']`.

Found while verifying [#15](https://github.com/gadget-bot/gadget-plugin-engagement-ledger/pull/15) (gadget v0.9.0 bump) — that PR's `lint` and `test (go 1.26)` are green; only the pre-existing `test (go 1.25)` failure is blocking it, unrelated to that change.

## Test plan

- [x] Confirmed `go: go.mod requires go >= 1.26 (running go 1.25.12; ...)` is the exact failure on the `main` commit that merged #12, before any of my changes
- [ ] After merge, confirm `main`'s CI goes green
